### PR TITLE
Add iNaturalist to Environment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Below is a curated list of awesome software and other resources to enable those 
  * [The Radix Center](https://radixcenter.org/) - Community-based urban sustainability / agriculture education center in Albany, NY.
  * [The Bucket Brigade](http://www.labucketbrigade.org/) - A Norco, LA - based citizen science group fighting for environmental justice.
  * [Safecast](http://blog.safecast.org/) - An online citizen science project collecting and visualizing radioactivity data across the globe.
+ * [iNaturalist](https://www.inaturalist.org/) - A joint initiative of the California Academy of Sciences and the National Geographic Society, enabling anyone to record observations of biodiversity; data contributed to science and the GBIF.
  * [Rainforest Connection](https://rfcx.org/) - Project sing old smartphones as sensors to combat illegal logging.
 
 ### Other


### PR DESCRIPTION
iNaturalist is one of the largest citizen science platforms for biodiversity observation. Managed jointly by the California Academy of Sciences and the National Geographic Society, it allows anyone to record and share species observations. Data contributed by users is automatically shared with the Global Biodiversity Information Facility (GBIF), making it a significant source of scientific biodiversity records — over 250 million observations to date.

Added to the "Citizen Science Spaces and Projects" > "Environment" section, where similar community-based environmental observation projects are listed.